### PR TITLE
Update network with clusters

### DIFF
--- a/app/controllers/api/v1/networks_controller.rb
+++ b/app/controllers/api/v1/networks_controller.rb
@@ -49,9 +49,14 @@ class Api::V1::NetworksController < Api::V1::ApiController
   end
 
   def network_params
-    params.require(:network).permit(:id, :name, :description, options: [:nodes, :edges],
+    params.require(:network).permit(:id, :name, :description,options: [:nodes, :edges],
       query: [countries: [], cpvs:[], years: [], procuring_entities: [], suppliers: []],
-      graph: [ nodes: [], edges: []] )
+      graph: [
+        nodes: [:id, :value, :label, :type, :color, flags: [:median]],
+        edges: [:from, :to, :value, flags: [:percent_contracts, :x_same_city]],
+        clusters: [:id, :name, :type, node_ids: []]
+      ]
+    )
   end
 
   private

--- a/app/serializers/network_serializer.rb
+++ b/app/serializers/network_serializer.rb
@@ -7,6 +7,8 @@ class NetworkSerializer < ActiveModel::Serializer
   end
 
   def count
-    return { nodes_count: graph[:nodes].size, edges_count: graph[:edges].size }
+    nodes_count = graph[:nodes].nil? ? 0 : graph[:nodes].size
+    edges_count = graph[:edges].nil? ? 0 : graph[:edges].size
+    return { nodes_count: nodes_count, edges_count: edges_count }
   end
 end


### PR DESCRIPTION
@ca1yps0  @nightsh 

This PR gives you the ability to update networks with `clusters`: 

`PUT/PATCH /networks/{:id}`

```json
{
    "graph": {
        "clusters": [
            {
                "id": "uniqueId",
                "name": "clusterName",
                "type": "supplier/procuring_entity",
                "node_ids": [1136543, 12450067] #slug_ids of actors involved
            }
        ]
    }
}
```

Be aware that updating the `query` or `options` attributes causes the network `graph` to be regenerated and to overwrite the `clusters`.
So only update what changed i.e. the `graph` attribute. 