### PR TITLE
Second take on autocomplete

### DIFF
--- a/app/controllers/api/v1/autocomplete_controller.rb
+++ b/app/controllers/api/v1/autocomplete_controller.rb
@@ -2,21 +2,10 @@ class Api::V1::AutocompleteController < Api::V1::ApiController
   include SearchResponseFormatter
 
   def actor_names
-    results = Supplier.es.client.suggest(
-      index: 'autocomplete',
-      body: {
-        suggestions: {
-          text: curated_params[:text],
-          completion: {
-            field: 'suggest',
-            size: curated_params[:max_suggestions]
-          }
-        }
-      }
-    )
-    suggestions = results.fetch('suggestions', [])[0].fetch('options', [])
-    render json: search_json_response(count: suggestions.size,
-     results: suggestions.map{|res| res['payload']}), status: 200
+    request = Search::AutocompleteSearch.new(curated_params[:text],
+      curated_params[:max_suggestions])
+    render json: search_json_response(count: request.count,
+      results: request.search), status: 200
    rescue => e
      render_error(e.message)
   end

--- a/app/controllers/api/v1/networks_controller.rb
+++ b/app/controllers/api/v1/networks_controller.rb
@@ -49,9 +49,14 @@ class Api::V1::NetworksController < Api::V1::ApiController
   end
 
   def network_params
-    params.require(:network).permit(:id, :name, :description, options: [:nodes, :edges],
+    params.require(:network).permit(:id, :name, :description,options: [:nodes, :edges],
       query: [countries: [], cpvs:[], years: [], procuring_entities: [], suppliers: []],
-      graph: [ nodes: [], edges: []] )
+      graph: [
+        nodes: [:id, :value, :label, :type, :color, flags: [:median]],
+        edges: [:from, :to, :value, flags: [:percent_contracts, :x_same_city]],
+        clusters: [:id, :name, :type, node_ids: []]
+      ]
+    )
   end
 
   private

--- a/app/indices/autocomplete.rb
+++ b/app/indices/autocomplete.rb
@@ -1,0 +1,104 @@
+module Indices
+  class Autocomplete < Base
+
+    def initialize
+      super
+      @mapping = {
+        prefix_name: false,
+        index_name: 'autocomplete',
+        index_options: {
+          settings: {
+            index: {
+              analysis: {
+                filter: {
+                  my_asciifolding_filter: {
+                    type: 'asciifolding',
+                    preserve_original: true
+                  },
+                  my_edgeNGram_filter: {
+                      type: 'edge_ngram',
+                      min_gram: 1,
+                      max_gram: 20
+                  },
+                },
+                analyzer: {
+                  my_edgeNGram_analyzer: {
+                    tokenizer: 'standard',
+                    filter: ['lowercase', 'my_asciifolding_filter', 'unique', 'my_edgeNGram_filter']
+                  },
+                },
+              },
+            }
+          },
+          mappings: {
+            suppliers: {
+              properties: {
+                name: {
+                  type: 'string',
+                  analyzer: 'my_edgeNGram_analyzer'
+              },
+              x_slug_id: {
+                type: 'integer',
+                index: 'not_analyzed'
+              },
+              type: {
+                type: 'string',
+                index: 'not_analyzed'
+              }
+            }
+          },
+          procuring_entity: {
+            properties: {
+              name: {
+                type: 'string',
+                analyzer: 'my_edgeNGram_analyzer'
+              },
+              x_slug_id: {
+                type: 'integer',
+                index: 'not_analyzed'
+              },
+            }
+          },
+        }
+        }
+      }
+    end
+
+    def populate_index
+      self.index_mappings.each do |entity_name, properties|
+        x_slug_ids = Contract.not_in("#{entity_name}.name": nil)
+                             .distinct("#{entity_name}.x_slug_id").sort
+        step_size = 1000
+        steps = (x_slug_ids.size / step_size) + 1
+        last_id = nil
+        pb = nil
+        p "Started indexing #{self.index_name}"
+        steps.times do |step|
+           if last_id
+              current_ids = x_slug_ids.delete_if{ |el| el <= last_id }.take(step_size)
+           else
+             current_ids = x_slug_ids.take(step_size)
+           end
+           last_id = current_ids.last
+           entities = current_ids.map do |x_slug_id|
+             contract = Contract.where("#{entity_name}.x_slug_id": x_slug_id).first
+             entity = contract.method("#{entity_name}").call
+             entity = entity.first if entity.is_a?(Array)
+             json_entity = entity.try(:as_indexed_json).try(:as_json)
+             { index: { data: json_entity }.merge(_id: entity.id.to_s) }
+           end
+           index_data = {
+             index: self.index_name,
+             type: entity_name,
+             body: entities,
+           }
+           @client.bulk(index_data)
+           pb = ProgressBar.create(title: "#{self.index_name}: #{entity_name.capitalize}",
+                                    total: steps, format: '%t: %p%% %a |%b>%i| %E') if pb.nil?
+           pb.increment
+        end
+      end
+    end
+
+  end
+end

--- a/app/indices/base.rb
+++ b/app/indices/base.rb
@@ -1,0 +1,46 @@
+module Indices
+  class Base
+
+    attr_reader :mapping, :client, :index
+
+    def initialize
+      @mapping = {}
+      @client = Elasticsearch::Client.new(host: Mongoid::Elasticsearch.client_options[:host])
+    end
+
+    def index_name
+      self.mapping[:index_name]
+    end
+
+    def index_settings
+      self.mapping[:index_options][:settings]
+    end
+
+    def index_mappings
+      self.mapping[:index_options][:mappings]
+    end
+
+    def update_index
+      @index = Elasticsearch::API::Indices::IndicesClient.new(@client)
+      index_options = {
+        index: self.index_name,
+        body: self.index_settings,
+      }
+      @index.create(index_options) unless @index.exists(index_options)
+    end
+
+    def update_type_mappings
+      self.update_index
+      self.index_mappings.each do |type, properties|
+        type_mappings = {
+          index: self.index_name,
+          type: type,
+          body: {},
+        }
+        type_mappings[:body][type] = properties
+        @index.put_mapping(type_mappings)
+      end
+    end
+
+  end
+end

--- a/app/indices/contracts.rb
+++ b/app/indices/contracts.rb
@@ -1,0 +1,206 @@
+module Indices
+  class Contracts < Base
+
+    def initialize
+      super
+      @mapping = {
+        prefix_name: false,
+        index_name: 'contracts',
+        index_options: {
+          settings: {
+            index: {
+              requests: {
+                cache: { enable: true}
+              }
+            }
+          },
+          mappings: {
+            contract: {
+              properties: {
+                number_of_tenderers: {
+                  type: 'integer',
+                  index: 'not_analyzed'
+                },
+                contract_id: {
+                  type: 'string',
+                  index: 'not_analyzed'
+                },
+                additional_identifiers: {
+                  type: 'string',
+                  index: 'not_analyzed'
+                },
+                award_criteria:{
+                  type: 'string',
+                  index: 'not_analyzed'
+                },
+                procuring_entity: {
+                  type: 'nested',
+                  properties: {
+                    address: {
+                      type: 'nested',
+                      properties: {
+                        country_name: {
+                          type: 'string',
+                          index: 'not_analyzed'
+                        },
+                        locality:{
+                          type: 'string',
+                          index: 'not_analyzed'
+                        }
+                      }
+                    },
+                    x_slug: {
+                      type: 'string',
+                      index: 'not_analyzed'
+                    },
+                    x_slug_id: {
+                      type: 'integer',
+                      index: 'not_analyzed'
+                    },
+                    name: {
+                      type: 'string',
+                      index: 'not_analyzed'
+                    },
+                    contract_point: {
+                      type: 'nested',
+                      properties: {
+                        name: {type: 'string'}
+                      }
+                    }
+                  }
+                },
+                suppliers: {
+                  type: 'nested',
+                  properties: {
+                    name: {
+                      type: 'string',
+                      index: 'not_analyzed'
+                    },
+                    x_slug: {
+                      type: 'string',
+                      index: 'not_analyzed'
+                    },
+                    x_slug_id: {
+                      type: 'integer',
+                      index: 'not_analyzed'
+                    },
+                    x_same_city: {
+                      type: 'integer',
+                      index: 'not_analyzed'
+                    },
+                    address: {
+                      type: 'nested',
+                      properties: {
+                        locality: {
+                          type: 'string',
+                          index: 'not_analyzed'
+                        },
+                        country_name: {
+                          type: 'string',
+                          index: 'not_analyzed'
+                        }
+                      }
+                    }
+                  }
+                },
+                tender: {
+                  type: 'nested',
+                  properties: {
+                    value: {
+                      type: 'nested',
+                      properties: {
+                        amount: {type: 'double'},
+                        x_amount_eur: {type: 'double'},
+                        currency: {type: 'string'},
+                        x_vat: {type: 'double'},
+                        x_vatbool: {type: 'boolean'}
+                      }
+                    }
+                  }
+                },
+                award: {
+                  type: 'nested',
+                  properties:{
+                    date: {
+                      type: 'nested',
+                      properties: {
+                        x_year: {
+                          type: 'integer',
+                          index: 'not_analyzed'
+                        },
+                        x_month: {type: 'integer'},
+                        x_day: {type: 'integer'}
+                      }
+                    },
+                    min_value: {
+                      type: 'nested',
+                      properties: {
+                        amount: {type: 'double'},
+                        x_amount_eur: {type: 'double'}
+                      }
+                    },
+                    value: {
+                      type: 'nested',
+                      properties: {
+                        amount: {type: 'double'},
+                        x_amount_eur: {type: 'double'},
+                        currency: {type: 'string'},
+                        x_vat: {type: 'double'},
+                        x_vatbool: {type: 'boolean'}
+                      }
+                    },
+                    x_initial_value: {
+                      type: 'nested',
+                      properties: {
+                        amount: {type: 'double'},
+                        currency: {type: 'string'},
+                        x_vat: {type: 'double'},
+                        x_amount_eur: {type: 'double'},
+                        x_vatbool: {type: 'boolean'}
+                      }
+                    },
+                    contract_number: {
+                      type: 'string',
+                      index: 'not_analyzed'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    def populate_index
+      cursor = Contract.asc(:id)
+      step_size = 1000
+      steps = (cursor.count / step_size) + 1
+      last_id = nil
+      pb = nil
+      p "Started indexing #{self.index_name}"
+      steps.times do |step|
+         if last_id
+           docs = cursor.gt(id: last_id).limit(step_size).to_a
+         else
+           docs = cursor.limit(step_size).to_a
+         end
+         last_id = docs.last.try(:id)
+         contracts = docs.map do |obj|
+           json_object = obj.try(:as_indexed_json).try(:as_json)
+           { index: { data: json_object }.merge(_id: obj.id.to_s) }
+         end
+         index_data = {
+           index: self.index_name,
+           type: 'contract',
+           body: contracts,
+         }
+         @client.bulk(index_data)
+         pb = ProgressBar.create(title: self.index_name.capitalize,
+                                  total: steps, format: '%t: %p%% %a |%b>%i| %E') if pb.nil?
+         pb.increment
+      end
+    end
+
+  end
+end

--- a/app/indices/indices.rb
+++ b/app/indices/indices.rb
@@ -1,0 +1,6 @@
+require 'elasticsearch'
+require "#{Rails.root}/app/indices/base.rb"
+require "#{Rails.root}/app/indices/autocomplete.rb"
+require "#{Rails.root}/app/indices/contracts.rb"
+
+module Indices; end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -2,6 +2,8 @@ class Contract
   include Mongoid::Document
   include Mongoid::Elasticsearch
 
+  elasticsearch!
+
   # Associations
   embeds_one  :tender, inverse_of: :contract
   embeds_one  :award, inverse_of: :contract
@@ -29,176 +31,6 @@ class Contract
 
   accepts_nested_attributes_for :procuring_entity, :suppliers
 
-  # Mappings
-  elasticsearch!({
-    prefix_name: false,
-    index_name: 'contracts',
-    index_options: {
-      settings: {
-        index: {
-          requests: {
-            cache: { enable: true}
-          }
-        }
-      },
-      mappings: {
-        contract: {
-          properties: {
-            number_of_tenderers: {
-              type: 'integer',
-              index: 'not_analyzed'
-            },
-            contract_id: {
-              type: 'string',
-              index: 'not_analyzed'
-            },
-            additional_identifiers: {
-              type: 'string',
-              index: 'not_analyzed'
-            },
-            award_criteria:{
-              type: 'string',
-              index: 'not_analyzed'
-            },
-            procuring_entity: {
-              type: 'nested',
-              properties: {
-                address: {
-                  type: 'nested',
-                  properties: {
-                    country_name: {
-                      type: 'string',
-                      index: 'not_analyzed'
-                    },
-                    locality:{
-                      type: 'string',
-                      index: 'not_analyzed'
-                    }
-                  }
-                },
-                x_slug: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                },
-                x_slug_id: {
-                  type: 'integer',
-                  index: 'not_analyzed'
-                },
-                name: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                },
-                contract_point: {
-                  type: 'nested',
-                  properties: {
-                    name: {type: 'string'}
-                  }
-                }
-              }
-            },
-            suppliers: {
-              type: 'nested',
-              properties: {
-                name: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                },
-                x_slug: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                },
-                x_slug_id: {
-                  type: 'integer',
-                  index: 'not_analyzed'
-                },
-                x_same_city: {
-                  type: 'integer',
-                  index: 'not_analyzed'
-                },
-                address: {
-                  type: 'nested',
-                  properties: {
-                    locality: {
-                      type: 'string',
-                      index: 'not_analyzed'
-                    },
-                    country_name: {
-                      type: 'string',
-                      index: 'not_analyzed'
-                    }
-                  }
-                }
-              }
-            },
-            tender: {
-              type: 'nested',
-              properties: {
-                value: {
-                  type: 'nested',
-                  properties: {
-                    amount: {type: 'double'},
-                    x_amount_eur: {type: 'double'},
-                    currency: {type: 'string'},
-                    x_vat: {type: 'double'},
-                    x_vatbool: {type: 'boolean'}
-                  }
-                }
-              }
-            },
-            award: {
-              type: 'nested',
-              properties:{
-                date: {
-                  type: 'nested',
-                  properties: {
-                    x_year: {
-                      type: 'integer',
-                      index: 'not_analyzed'
-                    },
-                    x_month: {type: 'integer'},
-                    x_day: {type: 'integer'}
-                  }
-                },
-                min_value: {
-                  type: 'nested',
-                  properties: {
-                    amount: {type: 'double'},
-                    x_amount_eur: {type: 'double'}
-                  }
-                },
-                value: {
-                  type: 'nested',
-                  properties: {
-                    amount: {type: 'double'},
-                    x_amount_eur: {type: 'double'},
-                    currency: {type: 'string'},
-                    x_vat: {type: 'double'},
-                    x_vatbool: {type: 'boolean'}
-                  }
-                },
-                x_initial_value: {
-                  type: 'nested',
-                  properties: {
-                    amount: {type: 'double'},
-                    currency: {type: 'string'},
-                    x_vat: {type: 'double'},
-                    x_amount_eur: {type: 'double'},
-                    x_vatbool: {type: 'boolean'}
-                  }
-                },
-                contract_number: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    wrapper: :load
-  })
-
   def as_json(options={})
     result = super({:except => [:additional_identifiers, :contract_id, :x_lot,
       :x_additional_information, :x_url, :contract_number, :x_NUTS] }.merge(options))
@@ -206,6 +38,10 @@ class Contract
     result[:suppliers] = suppliers.map{|s| s.as_json}
     result[:procuring_entity] = procuring_entity.as_json
     result
+  end
+
+  def as_indexed_json
+    self.as_json[self.model_name.element]
   end
 
 end

--- a/app/models/procuring_entity.rb
+++ b/app/models/procuring_entity.rb
@@ -1,6 +1,5 @@
 class ProcuringEntity
   include Mongoid::Document
-  include Mongoid::Elasticsearch
 
   # Associations
   embedded_in :contract, inverse_of: :procuring_entity
@@ -15,82 +14,13 @@ class ProcuringEntity
   field :x_type, type: String
   field :x_slug_id, type: Integer, default: nil
 
-  # Mapping
-  elasticsearch!({
-    prefix_name: false,
-    index_name: 'autocomplete',
-    index_options: {
-      settings: {
-        index: {
-          analysis: {
-            analyzer: {
-              my_edgeNGram_analyzer: {
-                tokenizer: 'my_edgeNGram_tokenizer',
-                filter: ['lowercase', 'my_asciifolding_filter', 'unique']
-              }
-            },
-            tokenizer: {
-              my_edgeNGram_tokenizer: {
-                type: 'edgeNGram',
-                min_gram: 2,
-                max_gram: 6,
-                token_chars: ['letter', 'digit', 'punctuation']
-              }
-            },
-            filter: {
-              my_asciifolding_filter: {
-                type: 'asciifolding',
-                preserve_original: true
-              }
-            }
-          }
-        }
-      },
-      mappings: {
-        procuring_entity: {
-          properties: {
-            suggest: {
-              type: 'completion',
-              analyzer: 'my_edgeNGram_analyzer',
-              payloads: true,
-            },
-            name: {
-              type: 'string'
-            },
-            x_slug: {
-              type: 'string',
-              index: 'not_analyzed'
-            },
-            x_slug_id: {
-              type: 'integer',
-              index: 'not_analyzed'
-            }
-          }
-        }
-      }
-    },
-    wrapper: :load
-  })
-
-  # customize what gets sent to elasticsearch:
-  def as_indexed_json
-    name_words = self.name.to_s.gsub(/\s([[:punct:]])\s/, '\1').split(/\s/)
-    name_words.append(self.name.to_s)
-    name_tokens = name_words.map{|word| word.gsub(/[[:punct:]]/, '')}
-    self.attributes.except('_id').merge!({
-      'suggest': {
-        'input': name_tokens + name_words,
-        'output': self.name,
-        'payload': {
-          'name': self.name,
-          'x_slug_id': self.x_slug_id
-        }
-      }
-    })
-  end
-
   def as_json(options={})
     super({:except => [:address,:contract_point]}.merge(options))
   end
 
+  def as_indexed_json
+    obj = self.as_json[self.model_name.element].except(:x_slug)
+    obj[:type] = self.model_name.element
+    obj
+  end
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,6 +1,5 @@
 class Supplier
   include Mongoid::Document
-  include Mongoid::Elasticsearch
 
   # Associations
   embedded_in :contract
@@ -12,82 +11,14 @@ class Supplier
   field :x_slug_id, type: Integer, default: nil
   field :x_same_city, type: Integer, default: nil
 
-  # Mapping
-  elasticsearch!({
-    prefix_name: false,
-    index_name: 'autocomplete',
-    index_options: {
-      settings: {
-        index: {
-          analysis: {
-            analyzer: {
-              my_edgeNGram_analyzer: {
-                tokenizer: 'my_edgeNGram_tokenizer',
-                filter: ['lowercase', 'my_asciifolding_filter', 'unique']
-              }
-            },
-            tokenizer: {
-              my_edgeNGram_tokenizer: {
-                type: 'edgeNGram',
-                min_gram: 2,
-                max_gram: 6,
-                token_chars: ['letter', 'digit', 'punctuation']
-              }
-            },
-            filter: {
-              my_asciifolding_filter: {
-                type: 'asciifolding',
-                preserve_original: true
-              }
-            }
-          }
-        }
-      },
-      mappings: {
-        supplier: {
-          properties: {
-            suggest: {
-              type: 'completion',
-              analyzer: 'my_edgeNGram_analyzer',
-              payloads: true,
-            },
-            name: {
-              type: 'string'
-            },
-            x_slug: {
-              type: 'string',
-              index: 'not_analyzed'
-            },
-            x_slug_id: {
-              type: 'integer',
-              index: 'not_analyzed'
-            }
-          }
-        }
-      }
-    },
-    wrapper: :load
-  })
-
-  # customize what gets sent to elasticsearch:
-  def as_indexed_json
-    name_words = self.name.to_s.gsub(/\s([[:punct:]])\s/, '\1').split(/\s/)
-    name_words.append(self.name.to_s)
-    name_tokens = name_words.map{|word| word.gsub(/[[:punct:]]/, '')}
-    self.attributes.except('_id').merge!({
-      'suggest': {
-        'input': name_tokens + name_words,
-        'output': self.name,
-        'payload': {
-          'name': self.name,
-          'x_slug_id': self.x_slug_id
-        }
-      }
-    })
-  end
-
   def as_json(options={})
     super({:except => [:address]}.merge(options))
+  end
+
+  def as_indexed_json
+    obj = self.as_json[self.model_name.element].except(:x_slug)
+    obj[:type] = self.model_name.element
+    obj
   end
 
 end

--- a/app/serializers/network_serializer.rb
+++ b/app/serializers/network_serializer.rb
@@ -7,6 +7,8 @@ class NetworkSerializer < ActiveModel::Serializer
   end
 
   def count
-    return { nodes_count: graph[:nodes].size, edges_count: graph[:edges].size }
+    nodes_count = graph[:nodes].nil? ? 0 : graph[:nodes].size
+    edges_count = graph[:edges].nil? ? 0 : graph[:edges].size
+    return { nodes_count: nodes_count, edges_count: edges_count }
   end
 end

--- a/app/services/search/autocomplete_search.rb
+++ b/app/services/search/autocomplete_search.rb
@@ -1,0 +1,33 @@
+class Search::AutocompleteSearch
+  attr_accessor :request, :result
+
+  def initialize(text, max_suggestions=10)
+    @request = {
+      size: max_suggestions,
+      body: {
+        query: {
+          match: {
+            name: text
+          }
+        }
+      }
+    }
+  end
+
+  def search
+    @result = request["hits"]["hits"].map{|result| result["_source"]}
+  rescue => e
+    return e
+  end
+
+  def count
+    request["hits"]["total"]
+  rescue => e
+    return e
+  end
+
+  def request
+    client = Elasticsearch::Client.new(host: Mongoid::Elasticsearch.client_options[:host])
+    client.search(index: 'autocomplete', **@request)
+  end
+end

--- a/config/initializers/mongoid-elasticsearch.rb
+++ b/config/initializers/mongoid-elasticsearch.rb
@@ -1,6 +1,3 @@
 # Put here because of https://github.com/rs-pro/mongoid-elasticsearch/issues/11
 Mongoid::Elasticsearch.autocreate_indexes = false
 Mongoid::Elasticsearch.client_options[:host] = ENV["ES_HOST"] || 'localhost'
-Contract
-Supplier
-ProcuringEntity

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -1,7 +1,15 @@
 namespace :es do
-  task :update_indices => ['es:require'] do
-    Mongoid::Elasticsearch.registered_models.each do |model_name|
+  task :update_indices => ['es:require'] do |task, args|
+    registered_models = Mongoid::Elasticsearch.registered_models
+    models_to_index = args.extras
+    unless models_to_index.empty?
+      indices = registered_models & models_to_index
+      p 'The models you passed are not registered indices' if indices.empty?
+    else
+      models_to_index = registered_models
+    end
 
+    models_to_index.each do |model_name|
       # Create the index if it doesn't exist
       model = model_name.constantize
       es_indices = model.es.client.indices

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -1,56 +1,25 @@
+require "#{Rails.root}/app/indices/indices.rb"
+include Indices
+
 namespace :es do
   task :update_indices => ['es:require'] do |task, args|
-    registered_models = Mongoid::Elasticsearch.registered_models
-    models_to_index = args.extras
-    unless models_to_index.empty?
-      indices = registered_models & models_to_index
+    registered_indices = Indices.constants.select {|c| Indices.const_get(c).is_a?(Class)}
+    registered_names = registered_indices.map(&:to_s).map(&:downcase).select{|name| name != 'base'}
+    indices_to_update = args.extras.map(&:downcase)
+    unless indices_to_update.empty?
+      indices = registered_names & indices_to_update
       p 'The models you passed are not registered indices' if indices.empty?
     else
-      models_to_index = registered_models
+      indices_to_update = registered_names
     end
 
-    models_to_index.each do |model_name|
-      # Create the index if it doesn't exist
-      model = model_name.constantize
-      es_indices = model.es.client.indices
-      index_options = {
-        index: model.es.index.name,
-        body: model.es.index.options[:settings]
-      }
-      es_indices.create(index_options) unless es_indices.exists(index_options)
-
-      # Update the index mapping for this model's type
-      model_mapping = index_options.merge(
-        type: model.es.index.type,
-        body: model.es.index.options[:mappings]
-      )
-      es_indices.put_mapping(model_mapping)
-
-      # Index the data in the collection
-      cursor = model.asc(:id)
-      step_size = 1000
-      steps = (cursor.count / step_size) + 1
-      last_id = nil
-      pb = nil
-      steps.times do |step|
-         if last_id
-           docs = cursor.gt(id: last_id).limit(step_size).to_a
-         else
-           docs = cursor.limit(step_size).to_a
-         end
-         last_id = docs.last.try(:id)
-         docs = docs.map do |obj|
-           if obj.es_index?
-             { index: {data: obj.as_indexed_json}.merge(_id: obj.id.to_s) }
-           else
-             nil
-           end
-         end.reject { |obj| obj.nil? }
-         model_data = model_mapping.merge({body: docs})
-         model.es.client.bulk(model_data)
-         pb = ProgressBar.create(title: model_name, total: steps, format: '%t: %p%% %a |%b>%i| %E') if pb.nil?
-         pb.increment
-      end
+    indices_to_update.each do |index_name|
+      class_name = index_name.camelize
+      index_class = Indices.const_get(class_name)
+      index = index_class.new()
+      index.update_index
+      index.update_type_mappings
+      index.populate_index
     end
   end
 end


### PR DESCRIPTION
Fixes #56 

Improvements:
- tokens are no longer kept in memory
- better fuzzy matching
- index only one actor `name` per `x_slug_id`
- refactored indexing code so that we can update indices individually

@nightsh 
To get suggestions: 

`GET api/v1/actor_autocomplete?text=plank&max_suggestions=25`

Default `max_suggestions` = 10
Response:

```json
 {
    "search": {
        "count": 1,
        "results": [
            {
                "name": "Peter Kattenbeck GmbH",
                "x_same_city": 0,
                "x_slug": "peter-kattenbeck-gmbh",
                "x_slug_id": 989848,
                "id": "58275167c91dcf4ed700018a",
                "type": "supplier"
            }
        ]
    }
}
``` 