### PR TITLE
Standardize average competition

### DIFF
--- a/app/services/search/actor_details.rb
+++ b/app/services/search/actor_details.rb
@@ -11,7 +11,7 @@ class Search::ActorDetails
       name: name,
       total_earnings: total_earnings,
       missing_values: missing_values,
-      median_tenderers: median_tenderers,
+      average_competition: median_number_tenderers,
       contracts: contracts_list
     }
   end
@@ -26,7 +26,7 @@ class Search::ActorDetails
     response(missing).deep_find('doc_count').round(2)
   end
 
-  def median_tenderers
+  def median_number_tenderers
     median = Search::Aggregation.new('number_of_tenderers', type: :percentiles)
     median_values = response(median).deep_find('values')
     median_50 = median_values['50.0']

--- a/app/services/vis/generator.rb
+++ b/app/services/vis/generator.rb
@@ -56,7 +56,7 @@ class Vis::Generator
     results.map! do |res|
       avrg_competition = res[:values][:"50.0"].to_f
       Vis::Node.new(res[:key], res[:name], res[field.to_sym].round(2),
-       'supplier', node_red_flags(avrg_competition))
+       'supplier', avrg_competition, node_red_flags(avrg_competition))
     end
     @nodes.push(*results)
   end
@@ -75,7 +75,7 @@ class Vis::Generator
     results.map! do |res|
       avrg_competition = res[:values][:"50.0"].to_f
       Vis::Node.new(res[:key], res[:name], res[field.to_sym].round(2),
-       'procuring_entity', node_red_flags(avrg_competition))
+       'procuring_entity', avrg_competition, node_red_flags(avrg_competition))
     end
     @nodes.push(*results)
   end

--- a/app/services/vis/generator.rb
+++ b/app/services/vis/generator.rb
@@ -44,19 +44,19 @@ class Vis::Generator
 
   def compute_suppliers(field, chained = nil)
     chained_agg = chained ? {chained_agg: chained} : {}
-    median = Search::Aggregation.new('number_of_tenderers',
+    avrg_competition = Search::Aggregation.new('number_of_tenderers',
      {type: :percentiles}.merge(chained_agg))
     values_supplier = Search::Aggregation.new('suppliers.x_slug_id',
-     embedded_agg: median)
+     embedded_agg: avrg_competition)
     results = get_results(values_supplier)
     names = get_names("suppliers")
     results.each_with_index do |a, i|
       a.merge!(names[i])
     end
     results.map! do |res|
-      median = res[:values][:"50.0"].to_f
+      avrg_competition = res[:values][:"50.0"].to_f
       Vis::Node.new(res[:key], res[:name], res[field.to_sym].round(2),
-       'supplier', node_red_flags(median))
+       'supplier', node_red_flags(avrg_competition))
     end
     @nodes.push(*results)
   end
@@ -120,9 +120,9 @@ class Vis::Generator
     end
   end
 
-  def node_red_flags(median)
+  def node_red_flags(avrg_competition)
     hash = {}
-    hash[:median] = median if median == 1
+    hash[:average_competition] = avrg_competition if avrg_competition == 1
     hash
   end
 

--- a/app/services/vis/node.rb
+++ b/app/services/vis/node.rb
@@ -10,7 +10,7 @@ class Vis::Node
     @label = label
     @type = type
     @color = COLORS[@type.to_sym]
-    @flags = flags.slice(:median)
+    @flags = flags.slice(:average_competition)
   end
 
 end

--- a/app/services/vis/node.rb
+++ b/app/services/vis/node.rb
@@ -4,12 +4,13 @@ class Vis::Node
 # FIXME:Remove me after the user has the ability to choose his own colors
   COLORS = {procuring_entity: 'rgb(246, 49, 136)', supplier: 'rgb(36, 243, 255)'}
 
-  def initialize(id, label, value, type, flags = {})
+  def initialize(id, label, value, type, average_competition, flags = {})
     @id = id
     @value = value
     @label = label
     @type = type
     @color = COLORS[@type.to_sym]
+    @average_competition = average_competition
     @flags = flags.slice(:average_competition)
   end
 


### PR DESCRIPTION
Fixes #68

Changes made in this PR:
- `median` flags from nodes has been renamed to `average_competition`
- a field called `average_competition` has been added to each node for display in node details
- the field `median_tenderers` in actor details was also renamed to `average_competition`